### PR TITLE
[WIP] Fix attribute bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is part of the Caravan project/dataset.
 
 _Caravan_ is an open community dataset of meteorological forcing data, catchment attributes, and discharge data for catchments around the world. Additionally, Caravan provides code to derive meteorological forcing data and catchment attributes in the cloud, making it easy for anyone to extend Caravan to new catchments. The vision of Caravan is to provide the foundation for a truly global open source community resource that will grow over time. 
 
-The Caravan dataset that was released together with the [paper](https://www.nature.com/articles/s41597-023-01975-w) and can be found [here](https://doi.org/10.5281/zenodo.7920164).
+The Caravan dataset that was released together with the [paper](https://www.nature.com/articles/s41597-023-01975-w) and can be found [here](10.5281/zenodo.7944025).
 
 ## About this repository
 
@@ -50,7 +50,7 @@ The Caravan dataset (and the corresponding manuscript) are currently under revis
 }
 ```
 
-Additionally, we would highly appreciated if you also cite the corresponding manuscripts of the source datasets. For details on the references, see the information included in the licenses folder of the [Caravan dataset](https://doi.org/10.5281/zenodo.7920164)
+Additionally, we would highly appreciated if you also cite the corresponding manuscripts of the source datasets. For details on the references, see the information included in the licenses folder of the [Caravan dataset](10.5281/zenodo.7944025)
 
 ## Contact
 

--- a/code/Caravan_part1_Earth_Engine.ipynb
+++ b/code/Caravan_part1_Earth_Engine.ipynb
@@ -1,6 +1,7 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "GGxjzJPFoCVO"
@@ -11,7 +12,7 @@
         "Author: Frederik Kratzert\n",
         "Contact: kratzert@google.com\n",
         "\n",
-        "This notebook is part of the [Caravan publication](https://eartharxiv.org/repository/view/3345/) and is the first of two notebooks that can be used to extend the dataset to new basins. This notebook is intended to be run on Google Colab so that the data exports to Earth Engine works as intended.\n",
+        "This notebook is part of the [Caravan publication](https://www.nature.com/articles/s41597-023-01975-w) and is the first of two notebooks that can be used to extend the dataset to new basins. This notebook is intended to be run on Google Colab so that the data exports to Earth Engine works as intended.\n",
         "\n",
         "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/kratzert/Caravan/blob/main/code/Caravan_part1_Earth_Engine.ipynb)\n",
         "\n",
@@ -30,7 +31,7 @@
         "\n",
         "- You need a Google account to be able to use Earth Engine\n",
         "- You need to add your shapefile as an [Asset](https://developers.google.com/earth-engine/guides/table_upload#upload-a-shapefile) to Google Earth Engine\n",
-        "- The shapefile needs to have one field that indicates the basin/gauge ID, which will be used to link the derived data to the individual basin. Make sure to adapt the corresponding variable in the \"General configuration\" section below.\n",
+        "- The shapefile needs to have one field that indicates the basin/gauge ID, which will be used to link the derived data to the individual basin. Make sure to adapt the corresponding variable in the \"General configuration\" section below. It is recommend to name this field `gauge_id`, which will safe you some adaptations across the 2nd notebook.\n",
         "\n",
         "Note: This notebook only derives catchment attributes and meteorological forcing data for each polygon in the shapefile layer. We do not provide additional streamflow data beyond what is already included in Caravan. \n",
         "\n",
@@ -52,18 +53,21 @@
         "If you use the Caravan dataset or this code, please consider referencing the original publication\n",
         "\n",
         "```bib\n",
-        "@article{kratzert2022caravan,\n",
-        "  title={Caravan - A global community dataset for large-sample hydrology},\n",
-        "  author={Kratzert, Frederik and Nearing, Grey and Addor, Nans and Erickson, Tyler and Gauch, Martin and Gilon, Oren and Gudmundsson, Lukas and Hassidim, Avinatan and Klotz, Daniel and Nevo, Sella and Shalev, Guy and Matias, Yossi},\n",
-        "  year={2022},\n",
-        "  publisher={EarthArxiv},\n",
-        "  doi={https://doi.org/10.31223/X50S70}\n",
+        "@article{kratzert2023caravan,\n",
+        "  title={Caravan-A global community dataset for large-sample hydrology},\n",
+        "  author={Kratzert, Frederik and Nearing, Grey and Addor, Nans and Erickson, Tyler and Gauch, Martin and Gilon, Oren and Gudmundsson, Lukas and Hassidim, Avinatan and Klotz, Daniel and Nevo, Sella and others},\n",
+        "  journal={Scientific Data},\n",
+        "  volume={10},\n",
+        "  number={1},\n",
+        "  pages={61},\n",
+        "  year={2023},\n",
+        "  publisher={Nature Publishing Group UK London}\n",
         "}\n",
-        "```\n",
-        "\n"
+        "```"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "EQvLi9Bm3eRi"
@@ -75,7 +79,7 @@
         "\n",
         "- `OUTPUT_FOLDER_NAME`: The name of the folder (in Google Drive) that is used to store the resulting data. For example, `OUTPUT_FOLDER_NAME = 'my_caravan_extension'` will create a folder called `my_caravan_extension` in the main directory of your Google Drive.\n",
         "\n",
-        "- `BASIN_ID_FIELD`: Name of the attribute field in the shapefile that contains the basin id. Make sure that this name does not conflict with any of the field names of HydroATLAS. For example, you could use something like `'gauge_id'` or `'basin_id'` but _not_ `'HYBAS_ID'`, `'PFAF_ID'`, or `'MAIN_BAS'`, which are all existing field names in HydroATLAS/HydroSHEDS.\n",
+        "- `BASIN_ID_FIELD`: Name of the attribute field in the shapefile that contains the basin id. It is recommended to name this field `gauge_id`. Make sure that this name does not conflict with any of the field names of HydroATLAS. For example, you could use something like `'gauge_id'` or `'basin_id'` but _not_ `'HYBAS_ID'`, `'PFAF_ID'`, or `'MAIN_BAS'`, which are all existing field names in HydroATLAS/HydroSHEDS.\n",
         "\n",
         "- `BASIN_PREFIX`: A short descriptive string that is prepended to each basin id and that should be unique within the Caravan data space. For example, we use `camels` for basins from the CAMELS (US) dataset and `camelsgb` from the CAMELS-GB dataset. The final name for each basin within the attribute table will be `{BASIN_PREFIX}_{GAUGE_ID}`. Note, if you already included such a prefix in the basin id field of your shapefile, leave this field as an empty string. Please also read the README in the Caravan dataset folder on details about the folder structure of the dataset.\n",
         "\n",
@@ -101,6 +105,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "PC2x5IKi4zAJ"
@@ -144,6 +149,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "wSdmgDYo6j5K"
@@ -265,7 +271,9 @@
         "    # two (or more) rivers merge.\n",
         "    direct_upstream_polygons = []\n",
         "    for i, next_down in enumerate(basin_data['NEXT_DOWN']):\n",
-        "        if (next_down == next_down_id) and (basin_data['weights'][i] > min_overlap_threshold):\n",
+        "        if ((next_down == next_down_id) and \n",
+        "         ((basin_data['weights'][i] > min_overlap_threshold) or \n",
+        "          (basin_data[\"weights\"][i] / basin_data[\"SUB_AREA\"][i] > 0.5))):\n",
         "            direct_upstream_polygons.append(i)\n",
         "\n",
         "    # Finally compute metrics. As all pour_point_properties are volumes or areas, we can simply compute the sum.\n",
@@ -277,6 +285,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "WdNCyuqa1wiz"
@@ -298,6 +307,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ABIHP_vr59Lt"
@@ -323,6 +333,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "WN6ioEX16RUv"
@@ -364,6 +375,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "3suZ9_O361nS"
@@ -385,18 +397,7 @@
         "id": "fdwv6IMh6sdf",
         "outputId": "62b7b9f3-9e74-45b6-b2c6-e820ad15bac5"
       },
-      "outputs": [
-        {
-          "ename": "",
-          "evalue": "",
-          "output_type": "error",
-          "traceback": [
-            "\u001b[1;31mRunning cells with 'Python 3.10.7 64-bit' requires ipykernel package.\n",
-            "\u001b[1;31mRun the following command to install 'ipykernel' into the Python environment. \n",
-            "\u001b[1;31mCommand: '/bin/python3 -m pip install ipykernel -U --user --force-reinstall'"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# get list list of all available hydroatlas feature properties\n",
         "property_names = hydro_atlas.first().propertyNames().getInfo()\n",
@@ -549,6 +550,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "6-7FVKUt8J3G"
@@ -627,7 +629,8 @@
         "        basin_id = polygon[\"properties\"][BASIN_ID_FIELD]\n",
         "\n",
         "        # check if the intersect is larger than the minimum overlap treshold\n",
-        "        if polygon[\"properties\"][\"Intersect\"] > MIN_OVERLAP_THRESHOLD:\n",
+        "        if ((polygon[\"properties\"][\"Intersect\"] > MIN_OVERLAP_THRESHOLD) or \n",
+        "            (polygon[\"properties\"][\"Intersect\"] / polygon[\"properties\"][\"SUB_AREA\"] > 0.5)):\n",
         "\n",
         "            # For some reason, the intersections for some basins are returned twice, leading to \n",
         "            # errors when computing the aggregates and especially the basin area. Here, we make\n",
@@ -648,6 +651,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "OFqsgWda8uoA"
@@ -745,6 +749,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "cMVR4PtS85mI"
@@ -792,6 +797,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "8hmtF5hZ9HC2"
@@ -826,6 +832,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ZBtxX7dj-p2V"
@@ -849,6 +856,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "v-S7hotuC96v"
@@ -862,7 +870,9 @@
         "\n",
         "- `END_DATE`: The last day of the period for which you request data. In Caravan, we include forcing data until December 31st, 2020. Note, that this date refers to data in UTC. To be able to include December 31st, 2020 in the local time zone you might actually need to request one additional day, depending on the location.\n",
         "\n",
-        " `ERA5L_BANDS`: The list of bands for which you wish to compute the spatial averages. You can change this at will, however to be compatible with Caravan, you should probably leave it as is. The names have to match the names in [this table](https://developers.google.com/earth-engine/datasets/catalog/ECMWF_ERA5_LAND_HOURLY#bands). **Note** The second notebook that processes the output of Earth Engine assumes that these bands are available. If you make changes here, you might need to adapt parts of the second notebook."
+        " `ERA5L_BANDS`: The list of bands for which you wish to compute the spatial averages. You can change this at will, however to be compatible with Caravan, you should probably leave it as is. The names have to match the names in [this table](https://developers.google.com/earth-engine/datasets/catalog/ECMWF_ERA5_LAND_HOURLY#bands). **Note** The second notebook that processes the output of Earth Engine assumes that these bands are available. If you make changes here, you might need to adapt parts of the second notebook.\n",
+        "\n",
+        " **Note**: Later, in the second notebook, we shift the ERA5-Land data from UTC-0 to local time, before aggregating to daily resolution. Here, we only consider days with values for all 24 hours. Therefore, adapt the `START_DATE` and the `END_DATE` according to the local timezone of your data with a 1 day buffer. That is, if your basins are east of UTC-0, adapt your `START_DATE` to include e.g. the 31st December. If the basins are west of UTC-0, adapt the `END_DATE` to include 1st January. If you want to be on the safe side, simply include a 1 day buffer on both side and then crop the data in the 2nd notebook."
       ]
     },
     {
@@ -895,6 +905,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "QinE2uM2EJSv"
@@ -943,6 +954,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "q7yMLA6_F0XO"
@@ -991,6 +1003,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "HFv3cfXqImAk"
@@ -1047,7 +1060,7 @@
     },
     "language_info": {
       "name": "python",
-      "version": "3.10.7"
+      "version": "3.10.9"
     },
     "vscode": {
       "interpreter": {

--- a/code/Caravan_part1_Earth_Engine.ipynb
+++ b/code/Caravan_part1_Earth_Engine.ipynb
@@ -742,10 +742,10 @@
         "\n",
         "    # basin area is the sum of the area of all intersecting fragments, also the smaller intersections that are ignored\n",
         "    # above.\n",
-        "    aggregated_results[basin]['area'] = sum(basin_data[\"weights\"])\n",
+        "    aggregated_results[basin]['area'] = sum(basin_data[\"area_fragments\"])\n",
         "\n",
         "    # We also store the fraction of the area considered during aggregation to the total basin area\n",
-        "    aggregated_results[basin]['area_fraction_used_for_aggregation'] = sum(masked_weights) / sum(basin_data[\"weights\"])"
+        "    aggregated_results[basin]['area_fraction_used_for_aggregation'] = sum(masked_weights) / sum(basin_data[\"area_fragments\"])"
       ]
     },
     {

--- a/code/Caravan_part2_local_postprocessing.ipynb
+++ b/code/Caravan_part2_local_postprocessing.ipynb
@@ -1,6 +1,7 @@
 {
   "cells": [
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "LfCmmM4_bnov"
@@ -59,18 +60,22 @@
         "If you use the Caravan dataset or this code, please consider referencing the original publication\n",
         "\n",
         "```bib\n",
-        "@article{kratzert2022caravan,\n",
-        "  title={Caravan - A global community dataset for large-sample hydrology},\n",
-        "  author={Kratzert, Frederik and Nearing, Grey and Addor, Nans and Erickson, Tyler and Gauch, Martin and Gilon, Oren and Gudmundsson, Lukas and Hassidim, Avinatan and Klotz, Daniel and Nevo, Sella and Shalev, Guy and Matias, Yossi},\n",
-        "  year={2022},\n",
-        "  publisher={EarthArxiv},\n",
-        "  doi={https://doi.org/10.31223/X50S70}\n",
+        "@article{kratzert2023caravan,\n",
+        "  title={Caravan-A global community dataset for large-sample hydrology},\n",
+        "  author={Kratzert, Frederik and Nearing, Grey and Addor, Nans and Erickson, Tyler and Gauch, Martin and Gilon, Oren and Gudmundsson, Lukas and Hassidim, Avinatan and Klotz, Daniel and Nevo, Sella and others},\n",
+        "  journal={Scientific Data},\n",
+        "  volume={10},\n",
+        "  number={1},\n",
+        "  pages={61},\n",
+        "  year={2023},\n",
+        "  publisher={Nature Publishing Group UK London}\n",
         "}\n",
         "```\n",
         "\n"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "4WpQz9BI7W0c"
@@ -100,6 +105,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "t5zxvfX_dyG3"
@@ -111,6 +117,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "GuFI8POptH9s"
@@ -182,6 +189,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "usfDPYJsnvYg"
@@ -225,6 +233,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
@@ -260,6 +269,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "myf_wuTiBnyM"
@@ -294,6 +304,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "Lsnl8SGZdjuj"
@@ -341,6 +352,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "u2qfQ1fv0loP"
@@ -429,6 +441,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "txsYf2Hv4-EG"
@@ -460,6 +473,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "rbFGEOi-jz-M"
@@ -509,6 +523,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "pTcPvHryr9Gb"
@@ -533,6 +548,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
@@ -552,6 +568,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
@@ -575,6 +592,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "4dE_mTOn4nI5"
@@ -619,6 +637,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ZcFTm2tE3ldt"
@@ -636,6 +655,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "mmQkGtVT6_D0"
@@ -669,6 +689,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "9LmcR6aG4ggq"
@@ -686,6 +707,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "pid2NKkG7sAj"
@@ -713,6 +735,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "9AHSa6Le-w_y"
@@ -756,6 +779,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "dZWmIQGVB_8O"
@@ -786,6 +810,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
@@ -802,6 +827,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "tV9cJ48kKpE_"


### PR DESCRIPTION
This PR fixes the bug mentioned in #22. Now, when searching for the most downstream HydroATLAS polygon that significantly intersects with the basin, small polygons (smaller than the `MIN_OVERLAP_THRESHOLD` are not ignored, if their fractional overlap is greater than 0.5. This was visually inspected to solve the problem in the effected basins. I already processed the attributes for all basins and all extensions and will upload a new dataset version tomorrow (it is late already) and will also contact the extension authors to update their extensions with the files that I derived for them.

This PR also includes a couple of suggestions by Marvin Höge and Efrat Morin to make the explanations/documentation in the notebooks (specifically the first one) clearer. Lastly, the bibtex entry was updated to point to the published paper.